### PR TITLE
Fix Responses API 400 by stripping model-only items; harden error handling; add long-instruction support

### DIFF
--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -1,0 +1,20 @@
+from utils import strip_model_only_items
+
+
+def test_strip_model_only_items():
+    items = [
+        {"type": "input_text", "text": "hello"},
+        {"type": "reasoning", "content": "private"},
+        {"type": "tool_result", "name": "computer", "result": {"ok": True}},
+        {"type": "output_text", "text": "final"},
+    ]
+    got = strip_model_only_items(items)
+    assert {"type": "input_text", "text": "hello"} in got
+    assert {
+        "type": "tool_result",
+        "name": "computer",
+        "result": {"ok": True},
+    } in got
+    assert not any(i.get("type") == "reasoning" for i in got)
+    assert not any(i.get("type") == "output_text" for i in got)
+


### PR DESCRIPTION
## Summary
- sanitize conversation history and strip `reasoning`/`output_text` before each API call
- detect and surface API error payloads instead of crashing
- add `--task-file` and env-based instruction loading to the CLI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b37530e7148321b8749a07d19485f8