### PR TITLE
Fix screenshot serialization using base64 input images

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -101,7 +101,9 @@ class Agent:
                 "acknowledged_safety_checks": pending_checks,
                 "output": {
                     "type": "input_image",
-                    "image_url": f"data:image/png;base64,{screenshot_base64}",
+                    # Send raw base64 rather than a data URL to comply with the
+                    # Responses API expectations for image input.
+                    "image_base64": screenshot_base64,
                 },
             }
 

--- a/simple_cua_loop.py
+++ b/simple_cua_loop.py
@@ -38,7 +38,9 @@ def handle_item(item, computer: Computer):
             "acknowledged_safety_checks": pending_checks,
             "output": {
                 "type": "input_image",
-                "image_url": f"data:image/png;base64,{screenshot_base64}",
+                # Provide the screenshot directly as base64 so the model can
+                # reconstruct the image without relying on an external URL.
+                "image_base64": screenshot_base64,
             },
         }
 

--- a/utils.py
+++ b/utils.py
@@ -38,12 +38,23 @@ def calculate_image_dimensions(base_64_image):
 
 
 def sanitize_message(msg: dict) -> dict:
-    """Return a copy of the message with image_url omitted for computer_call_output messages."""
+    """Return a copy of the message with large image payloads omitted.
+
+    This is useful for debug logging so that base64-encoded screenshots don't
+    overwhelm the console. The structure of the message is preserved, only the
+    image data is replaced with a placeholder string.
+    """
+
     if msg.get("type") == "computer_call_output":
         output = msg.get("output", {})
         if isinstance(output, dict):
             sanitized = msg.copy()
-            sanitized["output"] = {**output, "image_url": "[omitted]"}
+            new_output = dict(output)
+            if "image_url" in new_output:
+                new_output["image_url"] = "[omitted]"
+            if "image_base64" in new_output:
+                new_output["image_base64"] = "[omitted]"
+            sanitized["output"] = new_output
             return sanitized
     return msg
 
@@ -66,18 +77,18 @@ def strip_model_only_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 
 
 def coerce_input_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Prepare messages for the API request.
+
+    Drops non-dict items, filters out model-only item types and otherwise keeps
+    the messages unchanged so that fields like image_base64 remain intact for
+    the model to consume.
     """
-    Apply any existing message sanitization AND strip model-only items.
-    Keeps only dicts and drops Nones.
-    """
+
     out: List[Dict[str, Any]] = []
     for it in items:
         if it is None or not isinstance(it, dict):
             continue
-        sanitized = sanitize_message(it)
-        if sanitized is None:
-            continue
-        out.append(sanitized)
+        out.append(it)
     return strip_model_only_items(out)
 
 


### PR DESCRIPTION
## Summary
- send screenshots to the Responses API via `image_base64` instead of a data URL
- avoid stripping screenshot data before API calls and mask only for debug logging
- clarify utilities to preserve image fields while preparing request items

## Testing
- `pytest -q`
- ⚠️ `python - <<'PY' ... PY` *(proxy blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68b38367d29c8321a4ced81e6e2d2998