### PR TITLE
Remove acknowledge safety check callback parameter

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5,13 +5,6 @@ from computers.default import *
 from computers import computers_config
 
 
-def acknowledge_safety_check_callback(message: str) -> bool:
-    response = input(
-        f"Safety Check Warning: {message}\nDo you want to acknowledge and proceed? (y/n): "
-    ).lower()
-    return response.lower().strip() == "y"
-
-
 def main():
     parser = argparse.ArgumentParser(
         description="Select a computer environment from the available options."
@@ -50,7 +43,6 @@ def main():
     with ComputerClass() as computer:
         agent = Agent(
             computer=computer,
-            acknowledge_safety_check_callback=acknowledge_safety_check_callback,
         )
         items = []
 

--- a/simple_cua_loop.py
+++ b/simple_cua_loop.py
@@ -3,13 +3,6 @@ from computers import LocalPlaywrightComputer
 from utils import create_response, check_blocklisted_url
 
 
-def acknowledge_safety_check_callback(message: str) -> bool:
-    response = input(
-        f"Safety Check Warning: {message}\nDo you want to acknowledge and proceed? (y/n): "
-    ).lower()
-    return response.strip() == "y"
-
-
 def handle_item(item, computer: Computer):
     """Handle each item; may cause a computer action + screenshot."""
     if item["type"] == "message":  # print messages
@@ -27,15 +20,15 @@ def handle_item(item, computer: Computer):
         screenshot_base64 = computer.screenshot()
 
         pending_checks = item.get("pending_safety_checks", [])
-        for check in pending_checks:
-            if not acknowledge_safety_check_callback(check["message"]):
-                raise ValueError(f"Safety check failed: {check['message']}")
+        if pending_checks:
+            message = ", ".join(check["message"] for check in pending_checks)
+            raise ValueError(f"Safety check failed: {message}")
 
         # return value informs model of the latest screenshot
         call_output = {
             "type": "computer_call_output",
             "call_id": item["call_id"],
-            "acknowledged_safety_checks": pending_checks,
+            "acknowledged_safety_checks": [],
             "output": {
                 "type": "input_image",
                 "image_url": f"data:image/png;base64,{screenshot_base64}",


### PR DESCRIPTION
## Summary
- Drop `acknowledge_safety_check_callback` from `Agent`
- Simplify CLI and simple loop to raise on safety checks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4abda312883219422dc759a0f8b50